### PR TITLE
Update make_links.sh scripts for fv3-jedi & ioda

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,7 @@
 [submodule "IMS_proc"]
 	path = IMS_proc
-        #url = https://github.com/NOAA-PSL/land-IMS_proc.git
-	url = https://github.com/NOAA-EPIC/land-IMS_proc.git
-	branch = feature/release-v1.beta
+        url = https://github.com/NOAA-PSL/land-IMS_proc.git
+	branch = develop
 
 [submodule "add_jedi_incr"]
 	path = add_jedi_incr

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,8 @@
 [submodule "IMS_proc"]
 	path = IMS_proc
-	url = https://github.com/NOAA-PSL/land-IMS_proc.git
-	branch = develop
+        #url = https://github.com/NOAA-PSL/land-IMS_proc.git
+	url = https://github.com/NOAA-EPIC/land-IMS_proc.git
+	branch = feature/release-v1.beta
 
 [submodule "add_jedi_incr"]
 	path = add_jedi_incr

--- a/do_landDA_release.sh
+++ b/do_landDA_release.sh
@@ -401,7 +401,7 @@ fi
 NPROC_JEDI=6
 
 if [[ ! -e Data ]]; then
-    ln -s $JEDI_STATICDIR Data 
+    ln -sf $JEDI_STATICDIR Data 
 fi
 echo 'do_landDA: calling fv3-jedi' 
 echo ${JEDI_EXECDIR}

--- a/do_landDA_release.sh
+++ b/do_landDA_release.sh
@@ -80,12 +80,12 @@ fi
 #Make sure test data and ioda script are in place when first using new clone/build.
 cd ${LANDDADIR}/jedi/fv3-jedi/Data
 if [ ! -d "fieldmetadata" ] && [ ! -d "fv3files" ]; then
-  ./make_links.sh
+  sh make_links.sh
 fi
 
 cd ${LANDDADIR}/jedi/ioda
 if [ ! -e "imsfv3_scf2ioda.py" ]; then
-  ./make_links.sh
+  sh make_links.sh
 fi
 
 if [[ ! -e $WORKDIR ]]; then 

--- a/do_landDA_release.sh
+++ b/do_landDA_release.sh
@@ -76,6 +76,18 @@ if [[ ! -e ${OUTDIR}/DA ]]; then
     mkdir ${OUTDIR}/DA/hofx
 fi 
 
+
+#Make sure test data and ioda script are in place when first using new clone/build.
+cd ${LANDDADIR}/jedi/fv3-jedi/Data
+if [ ! -d "fieldmetadata" ] && [ ! -d "fv3files" ]; then
+  ./make_links.sh
+fi
+
+cd ${LANDDADIR}/jedi/ioda
+if [ ! -e "imsfv3_scf2ioda.py" ]; then
+  ./make_links.sh
+fi
+
 if [[ ! -e $WORKDIR ]]; then 
     mkdir $WORKDIR
 fi

--- a/do_landDA_release.sh
+++ b/do_landDA_release.sh
@@ -401,7 +401,7 @@ fi
 NPROC_JEDI=6
 
 if [[ ! -e Data ]]; then
-    ln -sf $JEDI_STATICDIR Data 
+    ln -fs $JEDI_STATICDIR Data 
 fi
 echo 'do_landDA: calling fv3-jedi' 
 echo ${JEDI_EXECDIR}

--- a/do_landDA_release.sh
+++ b/do_landDA_release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -le
+#!/bin/bash 
 # script to run the land DA. Currently only option is the snow LETKFOI.
 #
 # 1. stage the restarts. 
@@ -80,7 +80,7 @@ if [[ ! -e $WORKDIR ]]; then
     mkdir $WORKDIR
 fi
 
-
+    
 cd $WORKDIR 
 set -x
 ################################################
@@ -209,7 +209,6 @@ cat >> fims.nml << EOF
 EOF
     echo 'do_landDA: calling fIMS'
 #   source ${LANDDADIR}/land_mods_hera
-
     ${calcfIMS_EXEC}
     if [[ $? != 0 ]]; then
         echo "fIMS failed"
@@ -398,14 +397,14 @@ echo ${LOGDIR}
 echo ${JEDI_EXEC}
 
 if [[ $do_DA == "YES" ]]; then
-    mpiexec -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} letkf_land.yaml ${LOGDIR}/jedi_letkf.log
+    ${MPIEXEC} -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} letkf_land.yaml ${LOGDIR}/jedi_letkf.log
     if [[ $? != 0 ]]; then
         echo "JEDI DA failed"
         exit 10
     fi
 fi 
 if [[ $do_HOFX == "YES" ]]; then  
-    mpiexec -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} hofx_land.yaml ${LOGDIR}/jedi_hofx.log
+    ${MPIEXEC} -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} hofx_land.yaml ${LOGDIR}/jedi_hofx.log
     if [[ $? != 0 ]]; then
         echo "JEDI hofx failed"
         exit 10
@@ -435,7 +434,7 @@ EOF
 #   source ${LANDDADIR}/land_mods_hera
 
     # (n=6) -> this is fixed, at one task per tile (with minor code change, could run on a single proc). 
-    mpiexec -n 6 ${apply_incr_EXEC} ${LOGDIR}/apply_incr.log
+    ${MPIEXEC} -n 6 ${apply_incr_EXEC} ${LOGDIR}/apply_incr.log
     if [[ $? != 0 ]]; then
         echo "apply snow increment failed"
         exit 10

--- a/do_landDA_release.sh
+++ b/do_landDA_release.sh
@@ -1,0 +1,474 @@
+#!/bin/bash -le
+# script to run the land DA. Currently only option is the snow LETKFOI.
+#
+# 1. stage the restarts. 
+# 2. stage and process obs. 
+#    note: IMS obs prep currently requires model background, then conversion to IODA format.
+# 3. create the JEDI yamls.
+# 4. create pseudo ensemble (LETKF-OI).
+# 5. run JEDI.
+# 6. add increment file to restarts (and adjust any necessary dependent variables).
+# 7. clean up.
+
+# Clara Draper, Oct 2021.
+# Aug 2020, generalized for all DA types.
+
+# to-do: 
+# check that slmsk is always taken from the forecast file (oro files has a different definition)
+# make sure documentation is updated.
+
+#########################################
+# source namelist and setup directories
+#########################################
+#set -x
+if [[ $# -gt 0 ]]; then 
+    config_file=$1
+else
+    echo "do_landDA.sh: no config file specified, exting" 
+    exit 1
+fi
+
+echo "reading DA settings from $config_file"
+#source /opt/spack-stack/.bashenv
+#module restore landda
+
+GFSv17=${GFSv17:-"NO"}
+
+source $config_file
+
+LOGDIR=${OUTDIR}/DA/logs/
+RSTRDIR=${RSTRDIR:-$WORKDIR/restarts/tile/} # if running offline cycling will be here
+OBSDIR=${OBSDIR:-"${LANDDAROOT}/land-release/DA/"}
+
+# executable directories
+calcfIMS_EXEC=${BUILDDIR}/bin/calcfIMS.exe
+apply_incr_EXEC=${BUILDDIR}/bin/apply_incr.exe   
+
+# JEDI directories
+
+JEDI_EXECDIR=${JEDI_INSTALL}/fv3-bundle/build/bin
+IODA_BUILD_DIR=${JEDI_INSTALL}/ioda-bundle/build
+JEDI_STATICDIR=${LANDDADIR}/jedi/fv3-jedi/Data/
+
+# storage settings 
+SAVE_IMS="YES" # "YES" to save processed IMS IODA file
+SAVE_INCR="YES" # "YES" to save increment (add others?) JEDI output
+SAVE_TILE=${SAVE_TILE:-"NO"} # "YES" to save background in tile space
+REDUCE_HOFX="NO" # "YES" to remove duplicate hofx files (one per processor)
+KEEPDADIR=${KEEPDADIR:-"YES"} # delete DA workdir 
+
+echo 'THISDATE in land DA, '$THISDATE
+
+############################################################################################
+# TEMPORARY, UNTIL WE SORT OUT THE LATENCY ON THE IMS OBS
+# IMS data in file is from day before the file's time stamp 
+IMStiming=OBSDATE # FILEDATE - use IMS data for file's time stamp =THISDATE (NRT option) 
+                   # OBSDATE  - use IMS data for observation time stamp = THISDATE + 24 (hindcast option)
+
+############################################################################################
+
+# create output directories.
+if [[ ! -e ${OUTDIR}/DA ]]; then
+    mkdir -p ${OUTDIR}/DA
+    mkdir ${OUTDIR}/DA/IMSproc
+    mkdir ${OUTDIR}/DA/jedi_incr
+    mkdir ${OUTDIR}/DA/logs
+    mkdir ${OUTDIR}/DA/hofx
+fi 
+
+if [[ ! -e $WORKDIR ]]; then 
+    mkdir $WORKDIR
+fi
+
+
+cd $WORKDIR 
+set -x
+################################################
+# 1. FORMAT DATE STRINGS AND STAGE RESTARTS
+################################################
+
+INCDATE=${LANDDADIR}/incdate.sh
+
+YYYY=`echo $THISDATE | cut -c1-4`
+MM=`echo $THISDATE | cut -c5-6`
+DD=`echo $THISDATE | cut -c7-8`
+HH=`echo $THISDATE | cut -c9-10`
+
+PREVDATE=`${INCDATE} $THISDATE -$WINLEN`
+
+YYYP=`echo $PREVDATE | cut -c1-4`
+MP=`echo $PREVDATE | cut -c5-6`
+DP=`echo $PREVDATE | cut -c7-8`
+HP=`echo $PREVDATE | cut -c9-10`
+
+FILEDATE=${YYYY}${MM}${DD}.${HH}0000
+
+if [[ ! -e ${WORKDIR}/output ]]; then
+ln -s ${OUTDIR} ${WORKDIR}/output
+fi 
+
+if  [[ $SAVE_TILE == "YES" ]]; then
+for tile in 1 2 3 4 5 6 
+do
+cp ${RSTRDIR}/${FILEDATE}.sfc_data.tile${tile}.nc  ${RSTRDIR}/${FILEDATE}.sfc_data_back.tile${tile}.nc
+done
+fi 
+
+#stage restarts for applying JEDI update (files will get directly updated)
+for tile in 1 2 3 4 5 6 
+do
+  ln -fs ${RSTRDIR}/${FILEDATE}.sfc_data.tile${tile}.nc ${WORKDIR}/${FILEDATE}.sfc_data.tile${tile}.nc
+done
+cres_file=${WORKDIR}/${FILEDATE}.coupler.res
+if [[ -e  ${RSTRDIR}/${FILEDATE}.coupler.res ]]; then 
+    ln -sf ${RSTRDIR}/${FILEDATE}.coupler.res $cres_file
+else #  if not present, need to create coupler.res for JEDI 
+    cp ${LANDDADIR}/template.coupler.res $cres_file
+
+    sed -i -e "s/XXYYYY/${YYYY}/g" $cres_file
+    sed -i -e "s/XXMM/${MM}/g" $cres_file
+    sed -i -e "s/XXDD/${DD}/g" $cres_file
+    sed -i -e "s/XXHH/${HH}/g" $cres_file
+
+    sed -i -e "s/XXYYYP/${YYYP}/g" $cres_file
+    sed -i -e "s/XXMP/${MP}/g" $cres_file
+    sed -i -e "s/XXDP/${DP}/g" $cres_file
+    sed -i -e "s/XXHP/${HP}/g" $cres_file
+
+fi 
+
+
+################################################
+# 2. PREPARE OBS FILES
+################################################
+
+for ii in "${!OBS_TYPES[@]}"; # loop through requested obs
+do 
+
+  # get the obs file name 
+  if [ ${OBS_TYPES[$ii]} == "GTS" ]; then
+     obsfile=$OBSDIR/snow_depth/GTS/data_proc/${YYYY}${MM}/adpsfc_snow_${YYYY}${MM}${DD}${HH}.nc4
+  elif [ ${OBS_TYPES[$ii]} == "GHCN" ]; then 
+     obsfile=$OBSDIR/snow_depth/GHCN/data_proc/${YYYY}/ghcn_snwd_ioda_${YYYY}${MM}${DD}.nc
+  elif [ ${OBS_TYPES[$ii]} == "SYNTH" ]; then 
+     obsfile=$OBSDIR/synthetic_noahmp/IODA.synthetic_gswp_obs.${YYYY}${MM}${DD}${HH}.nc
+  elif [ ${OBS_TYPES[$ii]} == "SMAP" ]; then
+     obsfile=$OBSDIR/soil_moisture/SMAP/data_proc/${YYYY}/smap_${YYYY}${MM}${DD}T${HH}00.nc
+# Zofia - any processing of the SMAP obs goes here.
+  elif [ ${OBS_TYPES[$ii]} == "IMS" ]; then 
+     if [[ $IMStiming == "FILEDATE" ]]; then 
+            IMSDAY=${THISDATE} 
+     elif [[ $IMStiming == "OBSDATE" ]]; then
+            IMSDAY=`${INCDATE} ${THISDATE} +24`
+     else
+            echo 'UNKNOWN IMStiming selection, exiting' 
+            exit 10 
+     fi
+     YYYN=`echo $IMSDAY | cut -c1-4`
+     MN=`echo $IMSDAY | cut -c5-6`
+     DN=`echo $IMSDAY | cut -c7-8`
+     DOY=$(date -d "${YYYN}-${MN}-${DN}" +%j)
+     echo DOY is ${DOY}
+
+     if [[ $IMSDAY -gt 2014120200 ]]; then  ims_vsn=1.3 ; else  ims_vsn=1.2 ; fi
+     obsfile=${OBSDIR}/snow_ice_cover/IMS/${YYYY}/ims${YYYY}${DOY}_4km_v${ims_vsn}.nc
+
+  else
+     echo "do_landDA: Unknown obs type requested ${OBS_TYPES[$ii]}, exiting" 
+     exit 1 
+  fi
+
+  # check obs are available
+  if [[ -e $obsfile ]]; then
+    echo "do_landDA: ${OBS_TYPES[$ii]} observations found: $obsfile"
+    if [ ${OBS_TYPES[$ii]} != "IMS" ]; then 
+       ln -fs $obsfile  ${OBS_TYPES[$ii]}_${YYYY}${MM}${DD}${HH}.nc
+    fi 
+  else
+    echo "${OBS_TYPES[$ii]} observations not found: $obsfile"
+    JEDI_TYPES[$ii]="SKIP"
+  fi
+
+  # pre-process and call IODA converter for IMS obs.
+  if [[ ${OBS_TYPES[$ii]} == "IMS"  && ${JEDI_TYPES[$ii]} != "SKIP" ]]; then
+
+    if [[ -e fims.nml ]]; then
+        rm -rf fims.nml 
+    fi
+cat >> fims.nml << EOF
+ &fIMS_nml
+  idim=$RES, jdim=$RES,
+  otype=${TSTUB},
+  jdate=${YYYY}${DOY},
+  yyyymmddhh=${YYYY}${MM}${DD}.${HH},
+  imsformat=2,
+  imsversion=${ims_vsn},
+  IMS_OBS_PATH="${OBSDIR}/snow_ice_cover/IMS/${YYYY}/",
+  IMS_IND_PATH="${OBSDIR}/snow_ice_cover/IMS/index_files/"
+  /
+EOF
+    echo 'do_landDA: calling fIMS'
+#   source ${LANDDADIR}/land_mods_hera
+
+    ${calcfIMS_EXEC}
+    if [[ $? != 0 ]]; then
+        echo "fIMS failed"
+        exit 10
+    fi
+
+    IMS_IODA=imsfv3_scf2ioda_obs40.py
+    cp ${LANDDADIR}/jedi/ioda/${IMS_IODA} $WORKDIR
+
+    echo 'do_landDA: calling ioda converter' 
+#   source ${LANDDADIR}/ioda_mods_hera
+
+    ${PYTHON} ${IMS_IODA} -i IMSscf.${YYYY}${MM}${DD}.${TSTUB}.nc -o ${WORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.${TSTUB}.nc 
+    if [[ $? != 0 ]]; then
+        echo "IMS IODA converter failed"
+        exit 10
+    fi
+  fi #IMS
+
+done # OBS_TYPES
+
+################################################
+# 3. DETERMINE REQUESTED JEDI TYPE, CONSTRUCT YAMLS
+################################################
+
+do_DA="NO"
+do_HOFX="NO"
+
+for ii in "${!OBS_TYPES[@]}"; # loop through requested obs
+do
+   if [ ${JEDI_TYPES[$ii]} == "DA" ]; then 
+         do_DA="YES" 
+   elif [ ${JEDI_TYPES[$ii]} == "HOFX" ]; then
+         do_HOFX="YES" 
+   elif [ ${JEDI_TYPES[$ii]} != "SKIP" ]; then
+         echo "do_landDA:Unknown obs action ${JEDI_TYPES[$ii]}, exiting" 
+         exit 1
+   fi
+done
+
+if [[ $do_DA == "NO" && $do_HOFX == "NO" ]]; then 
+        echo "do_landDA:No obs found, not calling JEDI" 
+        exit 0 
+fi
+
+# if yaml is specified by user, use that. Otherwise, build the yaml
+if [[ $do_DA == "YES" ]]; then 
+
+   if [[ $YAML_DA == "construct" ]];then  # construct the yaml
+
+      cp ${LANDDADIR}/jedi/fv3-jedi/yaml_files/${DAtype}.yaml ${WORKDIR}/letkf_land.yaml
+
+      for ii in "${!OBS_TYPES[@]}";
+      do 
+        if [ ${JEDI_TYPES[$ii]} == "DA" ]; then
+        cat ${LANDDADIR}/jedi/fv3-jedi/yaml_files/${OBS_TYPES[$ii]}.yaml >> letkf_land.yaml
+        fi 
+      done
+
+   else # use specified yaml 
+      echo "Using user specified YAML: ${YAML_DA}"
+      cp ${LANDDADIR}/jedi/fv3-jedi/yaml_files/${YAML_DA} ${WORKDIR}/letkf_land.yaml
+   fi
+
+   sed -i -e "s/XXYYYY/${YYYY}/g" letkf_land.yaml
+   sed -i -e "s/XXMM/${MM}/g" letkf_land.yaml
+   sed -i -e "s/XXDD/${DD}/g" letkf_land.yaml
+   sed -i -e "s/XXHH/${HH}/g" letkf_land.yaml
+
+   sed -i -e "s/XXYYYP/${YYYP}/g" letkf_land.yaml
+   sed -i -e "s/XXMP/${MP}/g" letkf_land.yaml
+   sed -i -e "s/XXDP/${DP}/g" letkf_land.yaml
+   sed -i -e "s/XXHP/${HP}/g" letkf_land.yaml
+
+   sed -i -e "s/XXTSTUB/${TSTUB}/g" letkf_land.yaml
+   sed -i -e "s#XXTPATH#${TPATH}#g" letkf_land.yaml
+   sed -i -e "s/XXRES/${RES}/g" letkf_land.yaml
+   RESP1=$((RES+1))
+   sed -i -e "s/XXREP/${RESP1}/g" letkf_land.yaml
+
+   sed -i -e "s/XXHOFX/false/g" letkf_land.yaml  # do DA
+fi
+
+if [[ $do_HOFX == "YES" ]]; then 
+
+   if [[ $YAML_HOFX == "construct" ]];then  # construct the yaml
+
+      cp ${LANDDADIR}/jedi/fv3-jedi/yaml_files/${DAtype}.yaml ${WORKDIR}/hofx_land.yaml
+
+      for ii in "${!OBS_TYPES[@]}";
+      do 
+        if [ ${JEDI_TYPES[$ii]} == "HOFX" ]; then
+        cat ${LANDDADIR}/jedi/fv3-jedi/yaml_files/${OBS_TYPES[$ii]}.yaml >> hofx_land.yaml
+        fi 
+      done
+   else # use specified yaml 
+      echo "Using user specified YAML: ${YAML_HOFX}"
+      cp ${LANDDADIR}/jedi/fv3-jedi/yaml_files/${YAML_HOFX} ${WORKDIR}/hofx_land.yaml
+   fi
+
+   sed -i -e "s/XXYYYY/${YYYY}/g" hofx_land.yaml
+   sed -i -e "s/XXMM/${MM}/g" hofx_land.yaml
+   sed -i -e "s/XXDD/${DD}/g" hofx_land.yaml
+   sed -i -e "s/XXHH/${HH}/g" hofx_land.yaml
+
+   sed -i -e "s/XXYYYP/${YYYP}/g" hofx_land.yaml
+   sed -i -e "s/XXMP/${MP}/g" hofx_land.yaml
+   sed -i -e "s/XXDP/${DP}/g" hofx_land.yaml
+   sed -i -e "s/XXHP/${HP}/g" hofx_land.yaml
+
+   sed -i -e "s#XXTPATH#${TPATH}#g" hofx_land.yaml
+   sed -i -e "s/XXTSTUB/${TSTUB}/g" hofx_land.yaml
+   sed -i -e "s/XXRES/${RES}/g" hofx_land.yaml
+   RESP1=$((RES+1))
+   sed -i -e "s/XXREP/${RESP1}/g" hofx_land.yaml
+
+   sed -i -e "s/XXHOFX/true/g" hofx_land.yaml  # do HOFX
+
+fi
+
+################################################
+# 4. CREATE BACKGROUND ENSEMBLE (LETKFOI)
+################################################
+
+if [[ ${DAtype} == 'letkfoi_snow' ]]; then 
+
+    JEDI_EXEC="fv3jedi_letkf.x"
+
+    if [ $GFSv17 == "YES" ]; then
+        SNOWDEPTHVAR="snodl" 
+        # field overwrite file with GFSv17 variables.
+        cp ${LANDDADIR}/jedi/fv3-jedi/yaml_files/gfs-land-v17.yaml ${WORKDIR}/gfs-land-v17.yaml
+    else
+        SNOWDEPTHVAR="snwdph"
+    fi
+
+    B=30  # back ground error std for LETKFOI
+
+    # FOR LETKFOI, CREATE THE PSEUDO-ENSEMBLE
+    for ens in pos neg 
+    do
+        if [ -e $WORKDIR/mem_${ens} ]; then 
+                rm -r $WORKDIR/mem_${ens}
+        fi
+        mkdir $WORKDIR/mem_${ens} 
+        for tile in 1 2 3 4 5 6
+        do
+        cp ${WORKDIR}/${FILEDATE}.sfc_data.tile${tile}.nc  ${WORKDIR}/mem_${ens}/${FILEDATE}.sfc_data.tile${tile}.nc
+        done
+        cp ${WORKDIR}/${FILEDATE}.coupler.res ${WORKDIR}/mem_${ens}/${FILEDATE}.coupler.res
+    done
+       
+
+    echo 'do_landDA: calling create ensemble' 
+
+    # using ioda mods to get a python version with netCDF4
+
+    ${PYTHON} ${LANDDADIR}/letkf_create_ens.py $FILEDATE $SNOWDEPTHVAR $B
+    if [[ $? != 0 ]]; then
+        echo "letkf create failed"
+        exit 10
+    fi
+
+elif [[ ${DAtype} == 'letkfoi_smc' ]]; then 
+
+    JEDI_EXEC="${JEDI_EXECDIR}/fv3-bundle/build/bin/fv3jedi_letkf.x"
+
+    cp ${LANDDADIR}/jedi/fv3-jedi/yaml_files/gfs-soilMoisture.yaml ${WORKDIR}/gfs-soilMoisture.yaml
+
+fi
+
+################################################
+# 5. RUN JEDI
+################################################
+
+NPROC_JEDI=6
+
+if [[ ! -e Data ]]; then
+    ln -s $JEDI_STATICDIR Data 
+fi
+echo 'do_landDA: calling fv3-jedi' 
+echo ${JEDI_EXECDIR}
+echo ${LOGDIR}
+echo ${JEDI_EXEC}
+
+if [[ $do_DA == "YES" ]]; then
+    mpiexec -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} letkf_land.yaml ${LOGDIR}/jedi_letkf.log
+    if [[ $? != 0 ]]; then
+        echo "JEDI DA failed"
+        exit 10
+    fi
+fi 
+if [[ $do_HOFX == "YES" ]]; then  
+    mpiexec -n $NPROC_JEDI ${JEDI_EXECDIR}/${JEDI_EXEC} hofx_land.yaml ${LOGDIR}/jedi_hofx.log
+    if [[ $? != 0 ]]; then
+        echo "JEDI hofx failed"
+        exit 10
+    fi
+fi 
+
+################################################
+# 6. APPLY INCREMENT TO UFS RESTARTS 
+################################################
+
+if [[ $do_DA == "YES" ]]; then 
+
+  if [[ $DAtype == "letkfoi_snow" ]]; then 
+
+cat << EOF > apply_incr_nml
+&noahmp_snow
+ date_str=${YYYY}${MM}${DD}
+ hour_str=$HH
+ res=$RES
+ frac_grid=$GFSv17
+ orog_path="$TPATH"
+ otype="$TSTUB"
+/
+EOF
+
+    echo 'do_landDA: calling apply snow increment'
+#   source ${LANDDADIR}/land_mods_hera
+
+    # (n=6) -> this is fixed, at one task per tile (with minor code change, could run on a single proc). 
+    mpiexec -n 6 ${apply_incr_EXEC} ${LOGDIR}/apply_incr.log
+    if [[ $? != 0 ]]; then
+        echo "apply snow increment failed"
+        exit 10
+    fi
+
+  fi
+
+fi 
+
+################################################
+# 7. CLEAN UP
+################################################
+
+# keep IMS IODA file
+if [ $SAVE_IMS == "YES"  ]; then
+   if [[ -e ${WORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.C${RES}.nc ]]; then
+      cp ${WORKDIR}ioda.IMSscf.${YYYY}${MM}${DD}.C${RES}.nc ${OUTDIR}/DA/IMSproc/
+   fi
+fi 
+
+# keep increments
+if [ $SAVE_INCR == "YES" ] && [ $do_DA == "YES" ]; then
+   cp ${WORKDIR}/${FILEDATE}.xainc.sfc_data.tile*.nc  ${OUTDIR}/DA/jedi_incr/
+fi 
+
+# keep only one copy of each hofx files  
+# all obs are on every processor, or is this only for Ineffcient Distribution?
+if [ $REDUCE_HOFX == "YES" ]; then 
+   for file in $(ls ${OUTDIR}/DA/hofx/*${YYYY}${MM}${DD}*00[123456789].nc) 
+   do 
+    rm $file 
+   done
+fi 
+
+# clean up 
+if [[ $KEEPDADIR == "NO" ]]; then
+   rm -rf ${WORKDIR} 
+fi 

--- a/do_landDA_release.sh
+++ b/do_landDA_release.sh
@@ -46,7 +46,7 @@ apply_incr_EXEC=${BUILDDIR}/bin/apply_incr.exe
 
 # JEDI directories
 
-JEDI_EXECDIR=${JEDI_INSTALL}/fv3-bundle/build/bin
+JEDI_EXECDIR=${JEDI_EXECDIR:-"${JEDI_INSTALL}/fv3-bundle/build/bin"}
 IODA_BUILD_DIR=${JEDI_INSTALL}/ioda-bundle/build
 JEDI_STATICDIR=${LANDDADIR}/jedi/fv3-jedi/Data/
 
@@ -336,6 +336,8 @@ fi
 
 if [[ ${DAtype} == 'letkfoi_snow' ]]; then 
 
+    sed -i -e "/time invariant state fields:/,+6d" letkf_land.yaml
+    sed -i -e "/time invariant state fields:/d" letkf_land.yaml
     JEDI_EXEC="fv3jedi_letkf.x"
 
     if [ $GFSv17 == "YES" ]; then

--- a/jedi/fv3-jedi/Data/make_links.sh
+++ b/jedi/fv3-jedi/Data/make_links.sh
@@ -1,11 +1,15 @@
-#!/bin/ksh 
+#!/bin/bash
 
-if [ $# == 1 ]; then 
-        echo "setting jedi path to input $1"
-        jedi_path=$1
-else 
-        jedi_path="/scratch2/NCEPDEV/land/data/jedi/fv3-bundle/build/"
-fi 
+if [[ $# == 1 ]]; then
+  echo "setting jedi path to input $1"
+  jedi_path=$1
+elif [[ $HOSTNAME == *"Orion"* ]]; then
+  jedi_path="/work/noaa/epic-ps/role-epic-ps/contrib/fv3-bundle/build"
+elif [[ $HOSTNAME == *"hfe"* ]]; then
+  jedi_path="/scratch1/NCEPDEV/nems/role.epic/contrib/fv3-bundle/build"
+else
+ echo "Cannot determine where to link fv3-jedi test data. Please manually invoke make_links.sh"
+fi
 
 ln -s ${jedi_path}/fv3-jedi/test/Data/fv3files . 
 ln -s ${jedi_path}/fv3-jedi/test/Data/fieldmetadata . 

--- a/jedi/fv3-jedi/Data/make_links.sh
+++ b/jedi/fv3-jedi/Data/make_links.sh
@@ -11,6 +11,6 @@ else
  echo "Cannot determine where to link fv3-jedi test data. Please manually invoke make_links.sh"
 fi
 
-ln -s ${jedi_path}/fv3-jedi/test/Data/fv3files . 
-ln -s ${jedi_path}/fv3-jedi/test/Data/fieldmetadata . 
+ln -fs ${jedi_path}/fv3-jedi/test/Data/fv3files . 
+ln -fs ${jedi_path}/fv3-jedi/test/Data/fieldmetadata . 
 

--- a/jedi/fv3-jedi/yaml_files/letkfoi_snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/letkfoi_snow.yaml
@@ -8,13 +8,13 @@ geometry:
   npz: 64
   field metadata override: Data/fieldmetadata/gfs-land.yaml
 
-  time invariant state fields:
-    datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
-    filetype: fms restart
-    skip coupler file: true
-    state variables: [orog_filt]
-    datapath: XXTPATH
-    filename_orog: XXTSTUB.nc
+# time invariant state fields:
+#   datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+#   filetype: fms restart
+#   skip coupler file: true
+#   state variables: [orog_filt]
+#   datapath: XXTPATH
+#   filename_orog: XXTSTUB.nc
 
 window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
 window length: PT6H

--- a/jedi/fv3-jedi/yaml_files/letkfoi_snow.yaml
+++ b/jedi/fv3-jedi/yaml_files/letkfoi_snow.yaml
@@ -8,13 +8,13 @@ geometry:
   npz: 64
   field metadata override: Data/fieldmetadata/gfs-land.yaml
 
-# time invariant state fields:
-#   datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
-#   filetype: fms restart
-#   skip coupler file: true
-#   state variables: [orog_filt]
-#   datapath: XXTPATH
-#   filename_orog: XXTSTUB.nc
+  time invariant state fields:
+    datetime: XXYYYP-XXMP-XXDPTXXHP:00:00Z
+    filetype: fms restart
+    skip coupler file: true
+    state variables: [orog_filt]
+    datapath: XXTPATH
+    filename_orog: XXTSTUB.nc
 
 window begin: XXYYYP-XXMP-XXDPTXXHP:00:00Z
 window length: PT6H

--- a/jedi/ioda/make_links.sh
+++ b/jedi/ioda/make_links.sh
@@ -1,11 +1,15 @@
-#!/bin/ksh 
+#!/bin/bash
 
-if [ $# == 1 ]; then 
-        echo "setting jedi path to input $1"
-        jedi_path=$1
-else 
-        jedi_path="/scratch2/BMC/gsienkf/UFS-RNR/UFS-RNR-stack/external/ioda-bundle/"
-fi 
+if [[ $# == 1 ]]; then
+  echo "setting jedi path to input $1"
+  jedi_path=$1
+elif [[ $HOSTNAME == *"Orion"* ]]; then
+  jedi_path="/work/noaa/epic-ps/role-epic-ps/contrib/ioda-bundle"
+elif [[ $HOSTNAME == *"hfe"* ]]; then
+  jedi_path="/scratch1/NCEPDEV/nems/role.epic/contrib/ioda-bundle"
+else
+ echo "Cannot determine where to link IODA converter script. Please manually invoke make_links.sh"
+fi
 
-ln -s ${jedi_path}/iodaconv/src/land/imsfv3_scf2ioda.py . 
+ln -s ${jedi_path}/iodaconv/src/land/imsfv3_scf2ioda.py .
 

--- a/jedi/ioda/make_links.sh
+++ b/jedi/ioda/make_links.sh
@@ -11,5 +11,5 @@ else
  echo "Cannot determine where to link IODA converter script. Please manually invoke make_links.sh"
 fi
 
-ln -s ${jedi_path}/iodaconv/src/land/imsfv3_scf2ioda.py .
+ln -fs ${jedi_path}/iodaconv/src/land/imsfv3_scf2ioda.py .
 

--- a/settings_DA_release_template
+++ b/settings_DA_release_template
@@ -1,0 +1,47 @@
+# template for settings for calling do_landDA.sh 
+
+############################
+# if calling from submit_cycle,vars in this section will already be set. Otherwise, need to be set here.
+
+# THISDATE= # date YYYYMMDDHH
+# WORKDIR=/scratch2/BMC/gsienkf/${USER}/workdir/  # temporary directory where experiment is run from
+# OUTDIR=/scratch2/BMC/gsienkf/${USER}/cycle_land/${exp_name}/  # temporary directory where experiment is run from
+# RSTRDIR= #  if not specified, is constructed from $WORKDIR 
+# RES= #FV3 resolution
+# TPATH= # directory for orography files.
+# TSTUB= # filename stub for orography files. oro_C${RES} for atm only, oro_C${RES}.mx100 for atm/ocean.
+
+# directory where do_landDA.sh script is 
+LANDDADIR=${CYCLEDIR}/DA_update/ # if calling from submit_cycle.sh
+
+############################
+# DA options
+
+# DA algorithm and state being updated
+# options: "letkfoi_snow" , "letkf_snow"
+DAtype=
+
+# JEDI input obs. options : IMS, GHCN, GTS, SYNTH 
+OBS_TYPES=()   # format: ("OBS1" "OBS2") 
+# JEDI call type for each obs_type above. options: DA, HOFX
+JEDI_TYPES=()   # format ("DA" "HOFX") 
+
+#  DA window lenth. Will generally be the same as the FCSTLEN 
+WINLEN=
+
+# YAMLS. Options, either:
+# 1. "construct" to construct the YAML name, based on requested obs types and their availability 
+# 2. enter the desired YAML name (will not test for availability of obs)
+YAML_DA=construct
+YAML_HOFX=construct
+
+# OPTIONAL: CHANGE JEDI DIRECTORIES
+# if using different JEDI VERSION, will likely need to edit your yamls.
+#JEDI_EXECDIR=   # JEDI FV3 build directory
+#IODA_BUILD_DIR= # JEDI IODA-converter source directory
+#IMShr= # is assimilating IMS at hour other than 18, specify here.
+#OBSDIR= # to override default OBSDIR
+
+# OPTIONAL:delete workdirectory after DA update (do not use for within cycle_workflow)
+#KEEPDADIR=
+


### PR DESCRIPTION
This just adds some extra logic in the make_links.sh and do_landDA_release.sh scripts for linking fv3-jedi test data and the ioda converter based on which machine is used (or can default to $1, as before). The cycles were failing on Orion because it was trying to link the files from a Hera location. This should also prevent users from having to pre-stage/link these files manually.

Tested linking on Hera and Orion and seems to work.